### PR TITLE
revert  chunk splitting

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -47,37 +47,22 @@ export default defineConfig({
         manualChunks(id, meta) {
           for (const [key, value] of Object.entries({
             antd: 'antd',
-            '@ant-design': 'antd',
             'antd-mobile': 'antd',
             axios: 'base',
-            '@fortawesome': 'base',
-            'core-js': 'base',
             lodash: 'base',
             'lodash-es': 'base',
             '@emotion': 'base',
             react: 'base',
             'react-dom': 'base',
             scheduler: 'base',
-            'react-router': 'base',
             i18next: 'base',
           })) {
             if (id.includes(`node_modules/${key}/`)) {
-              return `vendor-${value}`;
+              return value;
             }
           }
 
-          if (/node_modules\/@?rc-/i.test(id)) {
-            return 'vendor-rc';
-          }
-
-          if (id.includes(moeflowSrc)) {
-            return 'moeflow';
-          }
-
-          if (id.includes('node_modules/')) {
-            return `vendor-other`;
-          }
-
+          // if (id.includes(moeflowSrc)) { return 'moeflow'; }
           return null;
         },
       },


### PR DESCRIPTION
broken in https://github.com/moeflow-com/moeflow-frontend/pull/35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the application's build process, resulting in fewer vendor groups and cleaner output chunk names for improved clarity during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->